### PR TITLE
Support Do Not Track to disable Google Analytics for user privacy

### DIFF
--- a/common/script/GoogleAnalytics_common.js
+++ b/common/script/GoogleAnalytics_common.js
@@ -4,4 +4,5 @@ m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
 ga('create', 'UA-61470721-1', 'auto');
+ga('require', 'dnt');
 ga('send', 'pageview');

--- a/contact/index.html
+++ b/contact/index.html
@@ -12,6 +12,7 @@
             load_parts("../");
         });
     </script>
+    <script src="https://storage.googleapis.com/outfox/dnt_min.js"></script>
     <script src="../common/script/GoogleAnalytics_common.js"></script>
 </head>
 <body>

--- a/event/index.html
+++ b/event/index.html
@@ -13,6 +13,7 @@
         });
     </script>
     <link rel="stylesheet" href="../common/css/event_project.css">
+    <script src="https://storage.googleapis.com/outfox/dnt_min.js"></script>
     <script src="../common/script/GoogleAnalytics_common.js"></script>
 </head>
 <body>

--- a/for_freshman/general_affairs_department.html
+++ b/for_freshman/general_affairs_department.html
@@ -12,6 +12,7 @@
             load_parts("../", [["pageBodySub", "pageBodySub", false]]);
         });
     </script>
+    <script src="https://storage.googleapis.com/outfox/dnt_min.js"></script>
     <script src="../common/script/GoogleAnalytics_common.js"></script>
 </head>
 <body>

--- a/for_freshman/index.html
+++ b/for_freshman/index.html
@@ -12,6 +12,7 @@
             load_parts("../", [["pageBodySub", "pageBodySub", false]]);
         });
     </script>
+    <script src="https://storage.googleapis.com/outfox/dnt_min.js"></script>
     <script src="../common/script/GoogleAnalytics_common.js"></script>
 </head>
 <body>

--- a/for_freshman/planning_department.html
+++ b/for_freshman/planning_department.html
@@ -12,6 +12,7 @@
             load_parts("../", [["pageBodySub", "pageBodySub", false]]);
         });
     </script>
+    <script src="https://storage.googleapis.com/outfox/dnt_min.js"></script>
     <script src="../common/script/GoogleAnalytics_common.js"></script>
 </head>
 <body>

--- a/for_freshman/public_relations_department.html
+++ b/for_freshman/public_relations_department.html
@@ -13,6 +13,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-easing/1.3/jquery.easing.min.js"></script>
     <script src="../common/script/camera.min.js"></script>
     <!--<script src="http://code.jquery.com/mobile/1.4.5/jquery.mobile-1.4.5.min.js"></script>-->
+    <script src="https://storage.googleapis.com/outfox/dnt_min.js"></script>
     <script src="../common/script/GoogleAnalytics_common.js"></script>
     <script type="text/javascript">
     jQuery(function () {

--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
         });
     </script>
 	<script type="text/javascript" src="common/script/slideshow.js"></script>
+    <script src="https://storage.googleapis.com/outfox/dnt_min.js"></script>
     <script src="./common/script/GoogleAnalytics_common.js"></script>
 </head>
 <body>

--- a/introduction/index.html
+++ b/introduction/index.html
@@ -12,6 +12,7 @@
             load_parts("../");
         });
     </script>
+    <script src="https://storage.googleapis.com/outfox/dnt_min.js"></script>
     <script src="../common/script/GoogleAnalytics_common.js"></script>
 </head>
 <body>

--- a/link/index.html
+++ b/link/index.html
@@ -12,6 +12,7 @@
             load_parts("../");
         });
     </script>
+    <script src="https://storage.googleapis.com/outfox/dnt_min.js"></script>
     <script src="../common/script/GoogleAnalytics_common.js"></script>
 </head>
 <body>

--- a/members/index.html
+++ b/members/index.html
@@ -12,6 +12,7 @@
             load_parts("../");
         });
     </script>
+    <script src="https://storage.googleapis.com/outfox/dnt_min.js"></script>
     <script src="../common/script/GoogleAnalytics_common.js"></script>
 </head>
 <body>

--- a/no_supported_browser.html
+++ b/no_supported_browser.html
@@ -4,6 +4,7 @@
 	<meta charset="shift_jis">
 	<meta http-equiv="content-type" content="text/html;charset=shift_jis">
 	<title>We will never support your browser</title>
+    <script src="https://storage.googleapis.com/outfox/dnt_min.js"></script>
     <script src="./common/script/GoogleAnalytics_common.js"></script>
 </head>
 <body>

--- a/privacy.html
+++ b/privacy.html
@@ -12,6 +12,7 @@
             load_parts("./");
         });
     </script>
+    <script src="https://storage.googleapis.com/outfox/dnt_min.js"></script>
     <script src="./common/script/GoogleAnalytics_common.js"></script>
 </head>
 <body>


### PR DESCRIPTION
未来研究室実行委員会ではWebページ改善のためにGoogleAnalyticsを利用しているが、Do Not Trackヘッダをユーザーが付与したときにこれを無効化するようにする。

これによりユーザは自らの意志で追跡を拒むことができるようになる。

ref:
- [Mozilla Firefox Web Browser — Do Not Track — Mozilla](https://www.mozilla.org/ja/firefox/dnt/)
- [DO NOT TRACK 実装ガイド | Mozilla Japan](https://www.mozilla.jp/static/docs/firefox/dnt-guide.pdf)
- [How to Make Google Analytics Respect “Do Not Track” | Outfox](http://www.outfox.com/do-not-track-for-google-analytics/)
- [プラグインを使用する  |  ウェブ向けアナリティクス（analytics.js）  |  Google Developers](https://developers.google.com/analytics/devguides/collection/analyticsjs/using-plugins)