### PR TITLE
Fix/1703/evemt detail on ios

### DIFF
--- a/event/2017/event_march/exhibition.html
+++ b/event/2017/event_march/exhibition.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html lang="ja">
 
 <head>

--- a/event/2017/event_march/resource/js/exhibition_creater.js
+++ b/event/2017/event_march/resource/js/exhibition_creater.js
@@ -1,4 +1,4 @@
-$(function(){
+﻿$(function(){
   'use strict';
 
   const description_block = document.getElementById("description");

--- a/event/2017/event_march/resource/js/exhibition_creater.js
+++ b/event/2017/event_march/resource/js/exhibition_creater.js
@@ -1,20 +1,20 @@
 ﻿$(function(){
   'use strict';
 
-  const description_block = document.getElementById("description");
-  const c = {
+  var description_block = document.getElementById("description");
+  var c = {
     list: [],
     oninit : function() {
       m.request({method: 'GET', url: './resource/data/exhibition.json'}).then(function(response){ c.list = response; });
     },
     view: function(ctrl){
-      const data = {
+      var data = {
         "chemistory": [],
         "geoscience": [],
         "math": [],
         "industrial": []
       };
-      const org_id_to_area_id_table = Object.freeze({
+      var org_id_to_area_id_table = Object.freeze({
         "rikoukaken": "chemistory",
         "ichikaken" : "chemistory",
         "nikaken"   : "chemistory",
@@ -31,10 +31,10 @@
         "acm"       : "industrial",
         "musenken"  : "industrial"
       });
-      const order = ["chemistory", "geoscience", "math", "industrial"];
+      var order = ["chemistory", "geoscience", "math", "industrial"];
       c.list.forEach(function(e){
-        const org_id = e.id.replace(/description_/, "");
-        let d = data[org_id_to_area_id_table[org_id]];
+        var org_id = e.id.replace(/description_/, "");
+        var d = data[org_id_to_area_id_table[org_id]];
         d.push(m("article#" + e.id + ".project_info", [
           m("div.project_title", [
             m("h2", e.title),


### PR DESCRIPTION
Safari, Chrome, Firefox, and all other iOS browser which has no original DOM engine on iOS9.x or before does not support ``const``/``let``.
http://caniuse.com/#feat=const

We need to support iOS 8.0 or greater so that use ``var`` instead of ``let``/``const``.

Another chose is using transcompiler like ``babel``, ``Google Closure Compiler``. However, all other javascript code which run on browser(not on Node.js) is not transcompiled. We need to refactor with ES2016( means rewrite all js) to do.