### PR TITLE
fix(redirect): fix redirect condition

### DIFF
--- a/no_supported_browser.html
+++ b/no_supported_browser.html
@@ -23,11 +23,29 @@
         return null;
       }
       var query = GetQueryString();
-      if("cause" in query){
-        document.addEventListener('DOMContentLoaded', function(){
-          document.getElementById("cause").innerHTML = "Cause: " + query["cause"];
-        })
-      }
+      try{
+        if(Object.prototype.hasOwnProperty.call(query, "cause")) {
+          var replace_cause = function() {
+            document.getElementById("cause").innerHTML = "Cause: " + query["cause"];
+          };
+
+          try{
+            if(document.addEventListener) {
+              try{
+                document.addEventListener("DOMContentLoaded", replace_cause);
+              } catch(e) {
+                document.addEventListener("load", replace_cause);
+              }
+            } else if(window.attachEvent) {
+              window.attachEvent("onload", replace_cause);
+            } else {
+              window.onload = replace_cause;
+            }
+          } catch(e){
+            window.onload = replace_cause;
+          }
+        }
+      } catch(e){/* nothing to do. */}
     }());
   </script>
 </head>


### PR DESCRIPTION
browserのバージョンではなく、ECMAScriptの機能サポート状況で判定するようにした。

おおむね

- IE10以前
- Firefox 45以前
- Safari 8以前
- Opera 12.10以前
- Android Default Browser(Chrome for Androidではない)すべて
- iOS7以前

を弾く。

詳細は

- http://kangax.github.io/compat-table/es5/
- https://kangax.github.io/compat-table/es6/

を参照のこと。

これにより、iOS10で弾かれる問題や一部のAndroidで弾かれる問題がなくなる(希望

ref:
- #9
- #28
- #64