### PR TITLE
fix: make background-color a bit orange

### DIFF
--- a/common/layout/index.css
+++ b/common/layout/index.css
@@ -1,5 +1,5 @@
 body {
-  background: #eee;
+  background: #f1ede7;
   min-width: 300px;
 }
 


### PR DESCRIPTION
ちょっと背景をオレンジっぽくしてあたたかみを足す提案。

色は無駄に次のプログラムで決定した。BT.709で規定される明るさは変化していない。

```python
"""This is a test program."""
# pylint: disable=C0103,C0325,C0326
import colorsys
import numpy as np
target_color = np.array([0xee, 0xee, 0xee])
# orange
input_color = [x/255.0 for x in [0xff, 0xa5, 0]]
hsl_adjusted_color = np.array([
    int(x*255.0) for x in colorsys.hls_to_rgb(
        colorsys.rgb_to_hls(*input_color)[0],# apply `input_color`
        # customize param
        90.0/101, # L
        19.0/101  # S
    )
])
# BT.709 convert matrix
CONV = np.array([
    [ 0.2126,  0.7152,  0.0722],
    [-0.1146, -0.3854,  0.500],
    [ 0.500,  -0.4542, -0.0458]
])
target_y = np.dot(CONV, target_color)[0]
hsl_adjusted_color_ycbcr = np.dot(CONV, hsl_adjusted_color)
# Set Y
hsl_adjusted_color_ycbcr[0] = target_y
result_color = np.dot(np.linalg.inv(CONV), hsl_adjusted_color_ycbcr)
print("#{0}".format(''.join(hex(int(x)) for x in result_color).replace("0x", "")))
```